### PR TITLE
Allow uris with issuer on parameters or label

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,6 @@ module.exports = {
         }
 
         ret.account = account;
-        ret.issuer = issuer;
 
         //
         // Parameters
@@ -143,10 +142,12 @@ module.exports = {
         ret.key = parameters.secret;
 
         // Issuer
-        if (parameters.issuer && (parameters.issuer !== issuer)) {
+        if (parameters.issuer && issuer && (parameters.issuer !== issuer)) {
             // If present, it must be equal to the "issuer" specified in the label.
             throw new OtpauthInvalidURL(ErrorType.INVALID_ISSUER);
         }
+
+        ret.issuer = issuer || parameters.issuer || '';
 
         // OTP digits
         ret.digits = 6;  // Default is 6

--- a/test/test.js
+++ b/test/test.js
@@ -84,6 +84,16 @@ describe('url-otpauth', function () {
         });
     });
 
+    it('should properly deconstruct an otpauth URL with issue in the parameters and without issuer in the label', function () {
+        assert.deepEqual(otpauth.parse('otpauth://totp/github.com/alice?issuer=GitHub&secret=JBSWY3DPEHPK3PXP'), {
+            account: 'github.com/alice',
+            digits: 6,
+            issuer: 'GitHub',
+            key: 'JBSWY3DPEHPK3PXP',
+            type: 'totp'
+        });
+    });
+
     it('should fail with an error parsing an URL with a wrong protocol', function onWrong() {
         assert.throws(function () {
             otpauth.parse('bogus');
@@ -121,12 +131,6 @@ describe('url-otpauth', function () {
     it('should fail when the account name is present but issuer is expected but missing', function () {
         assert.throws(function () {
             otpauth.parse('otpauth://totp/:alice@google.com?secret=JBSWY3DPEHPK3PXP');
-        }, otpauth.OtpauthInvalidURL);
-    });
-
-    it('should throw an error if issuer parameter is present but missing in the label', function () {
-        assert.throws(function () {
-            otpauth.parse('otpauth://totp/alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example');
         }, otpauth.OtpauthInvalidURL);
     });
 


### PR DESCRIPTION
Some uris only have issuer in the parameters and that should not fail.

Example uri from GitHub:
* `otpauth://totp/github.com/alice?issuer=GitHub&secret=JBSWY3DPEHPK3PXP`