### PR TITLE
allow label/issuer to be different

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,10 +148,10 @@ module.exports = {
         ret.key = parameters.secret;
 
         // Issuer
-        if (parameters.issuer && issuer && (parameters.issuer !== issuer)) {
+//        if (parameters.issuer && issuer && (parameters.issuer !== issuer)) {
             // If present, it must be equal to the "issuer" specified in the label.
-            throw new OtpauthInvalidURL(ErrorType.INVALID_ISSUER);
-        }
+//            throw new OtpauthInvalidURL(ErrorType.INVALID_ISSUER);
+//        }
 
         ret.issuer = issuer || parameters.issuer || '';
 

--- a/test/test.js
+++ b/test/test.js
@@ -156,7 +156,7 @@ describe('url-otpauth', function () {
         }, otpauth.OtpauthInvalidURL);
     });
 
-    it('should throw an error if issuer parameter and the one in the label are different', function () {
+    it.skip('should throw an error if issuer parameter and the one in the label are different', function () {
         assert.throws(function () {
             otpauth.parse('otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=OtherExample');
         }, otpauth.OtpauthInvalidURL);
@@ -178,5 +178,15 @@ describe('url-otpauth', function () {
         assert.throws(function () {
             otpauth.parse('otpauth://hotp/alice@google.com?secret=JBSWY3DPEHPK3PXP&algorithm=SHA2');
         }, otpauth.OtpauthInvalidURL);
+    });
+
+    it('should handle a complicated issuer in the label', function () {
+        assert.deepEqual(otpauth.parse('otpauth://totp/Slack%20(AB%20Fiskbyr%C3%A5n):johndoe@blah.se?secret=X2AOUG55JAXEA7PI&issuer=Slack'), {
+            account: 'johndoe@blah.se',
+            digits: 6,
+            issuer: 'Slack (AB Fiskbyrån)',
+            key: 'X2AOUG55JAXEA7PI',
+            type: 'totp'
+        });
     });
 });


### PR DESCRIPTION
Slack (mis-)uses the label so that the issuer-part (before the `:`) isn't the same as the issuer parameter. This trips up your parser.

I've created a quick hack, with test case in the PR, but wanted to discuss with you what the proper solution should be.